### PR TITLE
migrate from cobertura to jacoco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,26 +94,26 @@
                 <artifactId>maven-war-plugin</artifactId>
                 <version>3.2.2</version>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <executions>
-                    <execution>
-                        <id>cobertura</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>cobertura</goal>
-                        </goals>
-                        <configuration>
-                            <formats>
-                                <format>xml</format>
-                                <format>html</format>
-                            </formats>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+ <plugin>
+  <groupId>org.jacoco</groupId>
+  <artifactId>jacoco-maven-plugin</artifactId>
+  <version>0.8.6</version>
+  <executions>
+  	<execution>
+      	<id>prepare-agent</id>
+            <goals>
+             <goal>prepare-agent</goal>
+            </goals>
+      </execution>
+      <execution>
+            <id>report</id>
+            <phase>test</phase>
+               <goals>
+               <goal>report</goal>
+               </goals>
+        </execution>
+    </executions>
+ </plugin>
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
@@ -275,13 +275,13 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
                 <reportSets>
                     <reportSet>
                         <reports>
-                            <report>cobertura</report>
+                            <report>jacoco</report>
                         </reports>
                     </reportSet>
                 </reportSets>


### PR DESCRIPTION
tested the build via jenkins remote deployment for tomcat using JDK11,

Welcome to Java Maven Calculator Web App!!!
Sat Apr 02 21:18:22 UTC 2022

{"result":34,"time":"Sat Apr 02 21:17:25 UTC 2022","x":8,"y":26}
{"result":4,"time":"Sat Apr 02 21:17:48 UTC 2022","x":12,"y":8}
{"result":88,"time":"Sat Apr 02 21:18:00 UTC 2022","x":11,"y":8}
{"result":1,"time":"Sat Apr 02 21:18:11 UTC 2022","x":12,"y":12}

due to cobertura JDK8 below only support
migrating to jacoco for JDK9+ support
sun.tool jar file missing error fix